### PR TITLE
Cast $perPage to int

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -98,6 +98,7 @@ final class Engine extends AbstractEngine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
+        $perPage = (int) $perPage;
         $index = $builder->model->searchableAs();
         $searchRequest = $this->searchRequestFactory->makeFromBuilder($builder, compact('perPage', 'page'));
 


### PR DESCRIPTION
Laravel Scout accept `int $perPage` given as `string` or `int` type, however since this package wants to implements strict type it should definitely cast the value to `int`.