### PR TITLE
feat: Do not call toSearchableArray when deleting models

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -71,7 +71,7 @@ class Engine extends AbstractEngine
         }
 
         $index = $models->first()->searchableAs();
-        $documents = $this->documentFactory->makeFromModels($models);
+        $documents = $this->documentFactory->makeFromModels($models, false);
 
         $this->documentManager->index($index, $documents->all(), $this->refreshDocuments);
     }
@@ -86,7 +86,7 @@ class Engine extends AbstractEngine
         }
 
         $index = $models->first()->searchableAs();
-        $documents = $this->documentFactory->makeFromModels($models);
+        $documents = $this->documentFactory->makeFromModels($models, true);
 
         $this->documentManager->delete($index, $documents->all(), $this->refreshDocuments);
     }

--- a/src/Factories/DocumentFactory.php
+++ b/src/Factories/DocumentFactory.php
@@ -11,9 +11,9 @@ use UnexpectedValueException;
 
 class DocumentFactory implements DocumentFactoryInterface
 {
-    public function makeFromModels(EloquentCollection $models): BaseCollection
+    public function makeFromModels(EloquentCollection $models, bool $deleteMode = false): BaseCollection
     {
-        return $models->map(static function (Model $model) {
+        return $models->map(static function (Model $model) use ($deleteMode) {
             if (
                 in_array(SoftDeletes::class, class_uses_recursive(get_class($model))) &&
                 config('scout.soft_delete', false)
@@ -22,7 +22,7 @@ class DocumentFactory implements DocumentFactoryInterface
             }
 
             $documentId = (string)$model->getScoutKey();
-            $documentContent = array_merge($model->scoutMetadata(), $model->toSearchableArray());
+            $documentContent = $deleteMode ? $model->scoutMetadata() : array_merge($model->scoutMetadata(), $model->toSearchableArray());
 
             if (array_key_exists('_id', $documentContent)) {
                 throw new UnexpectedValueException(sprintf(

--- a/src/Factories/DocumentFactoryInterface.php
+++ b/src/Factories/DocumentFactoryInterface.php
@@ -7,5 +7,5 @@ use Illuminate\Support\Collection as BaseCollection;
 
 interface DocumentFactoryInterface
 {
-    public function makeFromModels(EloquentCollection $models): BaseCollection;
+    public function makeFromModels(EloquentCollection $models, bool $deleteMode = false): BaseCollection;
 }


### PR DESCRIPTION
When deleting models from search, we do not need to provide Elasticsearch with the full model data, just the "_id" field so that Elasticsearch knows which document to delete. Calling toSearchableArray on models that have been deleted from the database can cause issues if relations etc cannot be hydrated, and also creates an unnecessary database call. This commit adds an optional deleteMode argument to DocumentFactory. If this argument is true, then DocumentFactory no longer calls toSearchableArray on the models.