### PR TITLE
Add `whereNotIn` support

### DIFF
--- a/src/Factories/SearchParametersFactory.php
+++ b/src/Factories/SearchParametersFactory.php
@@ -77,6 +77,18 @@ class SearchParametersFactory implements SearchParametersFactoryInterface
             $filter = $filter->merge($whereIns);
         }
 
+        if (property_exists($builder, 'whereNotIns')) {
+            $whereNotIns = collect($builder->whereNotIns)->map(static fn (array $values, string $field) => [
+                'terms' => [$field => $values],
+            ])->values();
+
+            $filter = $filter->merge([[
+                'bool' => [
+                    'must_not' => $whereNotIns
+                ]
+            ]]);
+        }
+
         return $filter->isEmpty() ? null : $filter->all();
     }
 


### PR DESCRIPTION
- Added support for `whereNotIn` clause of [Laravel scout](https://laravel.com/docs/10.x/scout#where-clauses).
```php
User::search($search)
  ->whereNotIn('id', [1, 2, 3])
  ->get()
```