### PR TITLE
Bugfix for Laravel 13

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -53,6 +53,6 @@ final class ServiceProvider extends AbstractServiceProvider
             $this->configPath => config_path(basename($this->configPath)),
         ]);
 
-        resolve(EngineManager::class)->extend('elastic', static fn () => resolve(Engine::class));
+        resolve(EngineManager::class)->extend('elastic', fn () => resolve(Engine::class));
     }
 }


### PR DESCRIPTION
Laravel 13 now duplicates the closure with a new bound object and class scope. Static closures cannot have any bound object.

laravel/framework#57173

https://github.com/laravel/framework/blob/62df898ced958f7e10b3780074ce3b406e562c48/src/Illuminate/Support/Manager.php#L130